### PR TITLE
Kto 1246

### DIFF
--- a/src/kouta_index/filtered_list/search.clj
+++ b/src/kouta_index/filtered_list/search.clj
@@ -34,6 +34,11 @@
   (let [defined? (fn [k] (not (nil? (k filters))))]
     (or (defined? :nimi) (defined? :muokkaaja) (defined? :tila) (not (:arkistoidut filters)))))
 
+(defn- create-nimi-query
+  [search-term]
+  {:should (->> ["fi" "sv" "en"]
+                (map #(->match-query (str "nimi." %) search-term)))})
+
 (defn- ->nimi-filter
   [lng filters]
   (when-let [nimi (:nimi filters)]
@@ -41,7 +46,7 @@
       (->term-query :oid.keyword nimi)
       (if (uuid? nimi)
         (->term-query :id.keyword nimi)
-        (->match-query (str "nimi." (->lng lng)) nimi)))))
+        (create-nimi-query nimi)))))
 
 (defn- ->muokkaaja-filter
   [filters]

--- a/src/kouta_index/filtered_list/search.clj
+++ b/src/kouta_index/filtered_list/search.clj
@@ -36,8 +36,8 @@
 
 (defn- create-nimi-query
   [search-term]
-  {:should (->> ["fi" "sv" "en"]
-                (map #(->match-query (str "nimi." %) search-term)))})
+  {:bool {:should (->> ["fi" "sv" "en"]
+                       (map #(->match-query (str "nimi." %) search-term)))}})
 
 (defn- ->nimi-filter
   [filters]

--- a/src/kouta_index/filtered_list/search.clj
+++ b/src/kouta_index/filtered_list/search.clj
@@ -44,22 +44,22 @@
         (->match-query (str "nimi." (->lng lng)) nimi)))))
 
 (defn- ->muokkaaja-filter
-  [lng filters]
+  [filters]
   (when-let [muokkaaja (:muokkaaja filters)]
     (if (oid? muokkaaja)
       (->term-query :muokkaaja.oid muokkaaja)
       (->match-query :muokkaaja.nimi muokkaaja))))
 
 (defn- ->tila-filter
-  [lng filters]
+  [filters]
   (when-let [tila (:tila filters)]
     (->term-query :tila.keyword (->trimmed-lowercase tila))))
 
 (defn- ->filters
   [lng filters]
   (let [nimi      (->nimi-filter lng filters)
-        muokkaaja (->muokkaaja-filter lng filters)
-        tila      (->tila-filter lng filters)]
+        muokkaaja (->muokkaaja-filter filters)
+        tila      (->tila-filter filters)]
     (vec (remove nil? [nimi muokkaaja tila]))))
 
 (defn ->basic-oid-query

--- a/src/kouta_index/filtered_list/search.clj
+++ b/src/kouta_index/filtered_list/search.clj
@@ -40,7 +40,7 @@
                 (map #(->match-query (str "nimi." %) search-term)))})
 
 (defn- ->nimi-filter
-  [lng filters]
+  [filters]
   (when-let [nimi (:nimi filters)]
     (if (oid? nimi)
       (->term-query :oid.keyword nimi)
@@ -61,8 +61,8 @@
     (->term-query :tila.keyword (->trimmed-lowercase tila))))
 
 (defn- ->filters
-  [lng filters]
-  (let [nimi      (->nimi-filter lng filters)
+  [filters]
+  (let [nimi      (->nimi-filter filters)
         muokkaaja (->muokkaaja-filter filters)
         tila      (->tila-filter filters)]
     (vec (remove nil? [nimi muokkaaja tila]))))
@@ -76,16 +76,16 @@
   (->terms-query :id.keyword (vec ids)))
 
 (defn- ->query-with-filters
-  [lng base-query filters]
-  (let [filter-queries (->filters lng filters)]
+  [base-query filters]
+  (let [filter-queries (->filters filters)]
     {:bool (-> { :must base-query }
                (cond-> (false? (:arkistoidut filters)) (assoc :must_not (->term-query :tila.keyword "arkistoitu")))
                (cond-> (not-empty filter-queries) (assoc :filter filter-queries)))}))
 
 (defn- ->query
-  [lng base-query filters]
+  [base-query filters]
   (if (filters? filters)
-    (->query-with-filters lng base-query filters)
+    (->query-with-filters base-query filters)
     base-query))
 
 (defn- ->result
@@ -106,7 +106,7 @@
   (let [source (vec source-fields)
         from (->from page size)
         sort (->sort-array lng order-by order)
-        query (->query (->lng lng) base-query filters)]
+        query (->query base-query filters)]
     (debug-pretty { :_source source :from from :size size :sort sort :query query})
     (let [response (e/search index :_source source :from from :size size :sort sort :query query)]
       (->result response))))


### PR DESCRIPTION
- Luodaan entiteetin nimen match-query kaikille kielille. Aiemmin luotiin ainoastaan parametrina välitetylle kielelle, eli todennäköisesti kälin kielelle
- refaktoroitu pois käyttämättömiä lng parametreja